### PR TITLE
Transient Retry Strategy

### DIFF
--- a/Agero.Core.RestCaller.Tests/DefaultStrategyTests.cs
+++ b/Agero.Core.RestCaller.Tests/DefaultStrategyTests.cs
@@ -10,7 +10,7 @@ namespace Agero.Core.RestCaller.Tests
     [TestClass]
     public class DefaultStrategyTests
     {
-        static IRetryStrategy retryStrategy = new DefaultRetryStrategy();
+        private static IRetryStrategy _retryStrategy = new DefaultRetryStrategy();
 
         [DataTestMethod]
         [DataRow(WebExceptionStatus.ConnectFailure)]
@@ -24,7 +24,7 @@ namespace Agero.Core.RestCaller.Tests
         {
             var ex = new WebException(status.ToString(), status);
 
-            Assert.IsTrue(retryStrategy.IsTransient(ex));
+            Assert.IsTrue(_retryStrategy.IsTransient(ex));
         }
 
         [DataTestMethod]
@@ -46,7 +46,7 @@ namespace Agero.Core.RestCaller.Tests
         {
             var ex = new WebException(status.ToString(), status);
 
-            Assert.IsFalse(retryStrategy.IsTransient(ex));
+            Assert.IsFalse(_retryStrategy.IsTransient(ex));
         }
     }
 }

--- a/Agero.Core.RestCaller.Tests/DefaultStrategyTests.cs
+++ b/Agero.Core.RestCaller.Tests/DefaultStrategyTests.cs
@@ -1,0 +1,52 @@
+﻿using Agero.Core.RestCaller.Strategies;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+
+namespace Agero.Core.RestCaller.Tests
+{
+    [TestClass]
+    public class DefaultStrategyTests
+    {
+        static IRetryStrategy retryStrategy = new DefaultRetryStrategy();
+
+        [DataTestMethod]
+        [DataRow(WebExceptionStatus.ConnectFailure)]
+        [DataRow(WebExceptionStatus.ConnectionClosed)]
+        [DataRow(WebExceptionStatus.NameResolutionFailure)]
+        [DataRow(WebExceptionStatus.PipelineFailure)]
+        [DataRow(WebExceptionStatus.ReceiveFailure)]
+        [DataRow(WebExceptionStatus.SendFailure)]
+        [DataRow(WebExceptionStatus.Timeout)]
+        public void Status_IsTransient(WebExceptionStatus status)
+        {
+            var ex = new WebException(status.ToString(), status);
+
+            Assert.IsTrue(retryStrategy.IsTransient(ex));
+        }
+
+        [DataTestMethod]
+        [DataRow(WebExceptionStatus.CacheEntryNotFound)]
+        [DataRow(WebExceptionStatus.KeepAliveFailure)]
+        [DataRow(WebExceptionStatus.MessageLengthLimitExceeded)]
+        [DataRow(WebExceptionStatus.Pending)]
+        [DataRow(WebExceptionStatus.ProtocolError)]
+        [DataRow(WebExceptionStatus.ProxyNameResolutionFailure)]
+        [DataRow(WebExceptionStatus.RequestCanceled)]
+        [DataRow(WebExceptionStatus.RequestProhibitedByCachePolicy)]
+        [DataRow(WebExceptionStatus.RequestProhibitedByProxy)]
+        [DataRow(WebExceptionStatus.SecureChannelFailure)]
+        [DataRow(WebExceptionStatus.ServerProtocolViolation)]
+        [DataRow(WebExceptionStatus.Success)]
+        [DataRow(WebExceptionStatus.TrustFailure)]
+        [DataRow(WebExceptionStatus.UnknownError)]
+        public void Status_IsNotTransient(WebExceptionStatus status)
+        {
+            var ex = new WebException(status.ToString(), status);
+
+            Assert.IsFalse(retryStrategy.IsTransient(ex));
+        }
+    }
+}

--- a/Agero.Core.RestCaller/RESTCaller.cs
+++ b/Agero.Core.RestCaller/RESTCaller.cs
@@ -18,7 +18,7 @@ namespace Agero.Core.RestCaller
     {
         private const int WAIT_TIMEOUT_IN_MILLISECONDS_AFTER_FIRST_ATTEMPT = 100;
 
-        private IRetryStrategy retryStrategy;
+        private readonly IRetryStrategy _retryStrategy;
 
         /// <summary>
         /// Creates a new instance of <see cref="RESTCaller"/> using the
@@ -37,9 +37,9 @@ namespace Agero.Core.RestCaller
         /// determining if an error is transient or not.</param>
         public RESTCaller(IRetryStrategy retryStrategy)
         {
-            Check.ArgumentIsNull<IRetryStrategy>(retryStrategy, "retryStrategy");
+            Check.ArgumentIsNull(retryStrategy, nameof(retryStrategy));
 
-            this.retryStrategy = retryStrategy;
+            _retryStrategy = retryStrategy;
         }
 
         /// <summary>Makes request based on httpMethod</summary>
@@ -116,7 +116,7 @@ namespace Agero.Core.RestCaller
                     {
                         attemptErrors.Add(ex);
 
-                        if (attemptErrors.Count < maxAttempts && retryStrategy.IsTransient(ex))
+                        if (attemptErrors.Count < maxAttempts && _retryStrategy.IsTransient(ex))
                         {
                             Thread.Sleep(WAIT_TIMEOUT_IN_MILLISECONDS_AFTER_FIRST_ATTEMPT * attemptErrors.Count);
                             continue;
@@ -213,7 +213,7 @@ namespace Agero.Core.RestCaller
                     {
                         attemptErrors.Add(ex);
 
-                        if (attemptErrors.Count < maxAttempts && retryStrategy.IsTransient(ex))
+                        if (attemptErrors.Count < maxAttempts && _retryStrategy.IsTransient(ex))
                         {
                             await Task.Delay(WAIT_TIMEOUT_IN_MILLISECONDS_AFTER_FIRST_ATTEMPT * attemptErrors.Count).ConfigureAwait(false);
                             continue;

--- a/Agero.Core.RestCaller/RESTCaller.cs
+++ b/Agero.Core.RestCaller/RESTCaller.cs
@@ -1,6 +1,7 @@
 ﻿using Agero.Core.Checker;
 using Agero.Core.RestCaller.Exceptions;
 using Agero.Core.RestCaller.Extensions;
+using Agero.Core.RestCaller.Strategies;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -15,19 +16,31 @@ namespace Agero.Core.RestCaller
     /// <summary>REST client to make REST calls</summary>
     public class RESTCaller : IRESTCaller
     {
-        private static readonly IReadOnlyCollection<WebExceptionStatus> _transientWebExceptionStatuses =
-            new[]
-            {
-                WebExceptionStatus.ConnectFailure,
-                WebExceptionStatus.ConnectionClosed,
-                WebExceptionStatus.NameResolutionFailure,
-                WebExceptionStatus.PipelineFailure,
-                WebExceptionStatus.ReceiveFailure,
-                WebExceptionStatus.SendFailure,
-                WebExceptionStatus.Timeout
-            };
-
         private const int WAIT_TIMEOUT_IN_MILLISECONDS_AFTER_FIRST_ATTEMPT = 100;
+
+        private IRetryStrategy retryStrategy;
+
+        /// <summary>
+        /// Creates a new instance of <see cref="RESTCaller"/> using the
+        /// <see cref="DefaultRetryStrategy"/>.
+        /// </summary>
+        public RESTCaller()
+            : this(new DefaultRetryStrategy())
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="RESTCaller"/> using the
+        /// provided <see cref="IRetryStrategy"/>.
+        /// </summary>
+        /// <param name="retryStrategy">In implementation of <see cref="IRetryStrategy"/> to use when
+        /// determining if an error is transient or not.</param>
+        public RESTCaller(IRetryStrategy retryStrategy)
+        {
+            Check.ArgumentIsNull<IRetryStrategy>(retryStrategy, "retryStrategy");
+
+            this.retryStrategy = retryStrategy;
+        }
 
         /// <summary>Makes request based on httpMethod</summary>
         /// <param name="uri">Request URL</param>
@@ -103,7 +116,7 @@ namespace Agero.Core.RestCaller
                     {
                         attemptErrors.Add(ex);
 
-                        if (attemptErrors.Count < maxAttempts && _transientWebExceptionStatuses.Contains(ex.Status))
+                        if (attemptErrors.Count < maxAttempts && retryStrategy.IsTransient(ex))
                         {
                             Thread.Sleep(WAIT_TIMEOUT_IN_MILLISECONDS_AFTER_FIRST_ATTEMPT * attemptErrors.Count);
                             continue;
@@ -200,7 +213,7 @@ namespace Agero.Core.RestCaller
                     {
                         attemptErrors.Add(ex);
 
-                        if (attemptErrors.Count < maxAttempts && _transientWebExceptionStatuses.Contains(ex.Status))
+                        if (attemptErrors.Count < maxAttempts && retryStrategy.IsTransient(ex))
                         {
                             await Task.Delay(WAIT_TIMEOUT_IN_MILLISECONDS_AFTER_FIRST_ATTEMPT * attemptErrors.Count).ConfigureAwait(false);
                             continue;

--- a/Agero.Core.RestCaller/Strategies/DefaultRetryStrategy.cs
+++ b/Agero.Core.RestCaller/Strategies/DefaultRetryStrategy.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+
+namespace Agero.Core.RestCaller.Strategies
+{
+    /// <summary>
+    /// Default strategy for detecting transient failures.
+    /// </summary>
+    /// <remarks>
+    /// The strategy considers the following to be transient and retriable:
+    ///    WebExceptionStatus.ConnectFailure,
+    ///    WebExceptionStatus.ConnectionClosed,
+    ///    WebExceptionStatus.NameResolutionFailure,
+    ///    WebExceptionStatus.PipelineFailure,
+    ///    WebExceptionStatus.ReceiveFailure,
+    ///    WebExceptionStatus.SendFailure,
+    ///    WebExceptionStatus.Timeout
+    /// </remarks>
+    public class DefaultRetryStrategy : IRetryStrategy
+    {
+        private static readonly IReadOnlyCollection<WebExceptionStatus> _transientWebExceptionStatuses =
+            new[]
+            {
+                WebExceptionStatus.ConnectFailure,
+                WebExceptionStatus.ConnectionClosed,
+                WebExceptionStatus.NameResolutionFailure,
+                WebExceptionStatus.PipelineFailure,
+                WebExceptionStatus.ReceiveFailure,
+                WebExceptionStatus.SendFailure,
+                WebExceptionStatus.Timeout
+            };
+
+        /// <inheritDoc />
+        public bool IsTransient(WebException webException)
+        {
+            return _transientWebExceptionStatuses.Contains(webException.Status);
+        }
+    }
+}

--- a/Agero.Core.RestCaller/Strategies/DefaultRetryStrategy.cs
+++ b/Agero.Core.RestCaller/Strategies/DefaultRetryStrategy.cs
@@ -31,7 +31,11 @@ namespace Agero.Core.RestCaller.Strategies
                 WebExceptionStatus.Timeout
             };
 
-        /// <inheritDoc />
+        /// <summary>
+        /// Determines whether or not the error is transient.
+        /// </summary>
+        /// <param name="webException">The <see cref="WebException"/> to apply the strategy too.</param>
+        /// <returns><c>true</c> if the error is transient, otherwise <c>false</c>.</returns>
         public bool IsTransient(WebException webException)
         {
             return _transientWebExceptionStatuses.Contains(webException.Status);

--- a/Agero.Core.RestCaller/Strategies/IRetryStrategy.cs
+++ b/Agero.Core.RestCaller/Strategies/IRetryStrategy.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+
+namespace Agero.Core.RestCaller.Strategies
+{
+    /// <summary>
+    /// Interface implemented by retry strategies.
+    /// </summary>
+    public interface IRetryStrategy
+    {
+        /// <summary>
+        /// Determines whether or not the error is transient.
+        /// </summary>
+        /// <param name="webException">The <see cref="WebException"/> to apply the strategy too.</param>
+        /// <returns><c>true</c> if the error is transient, otherwise <c>false</c>.</returns>
+        bool IsTransient(WebException webException);
+    }
+}


### PR DESCRIPTION
Extracted the transient retry strategy logic out of RESTCaller into it's own class and interface. This allows consumers to define their own logic for what errors they consider transient.

The DefaultRetryStrategy is used if none is provided. There are no braking changes with this update.